### PR TITLE
Navigation & pagination fix

### DIFF
--- a/src/components/header/navigation/Routes.tsx
+++ b/src/components/header/navigation/Routes.tsx
@@ -19,7 +19,7 @@ export default function Routes() {
       >
         <Route path='*' element={<Navigate to='/' />} />
         <Route path='/' element={<Navigate to='/main' replace />} />
-
+        <Route path='/main' element={<MainPage />} />
         <Route path='/liquidations' element={<LiquidationsPage />} />
         <Route path='/perps' element={chainConfig.perps ? <PerpsOverviewPage /> : <MainPage />}>
           <Route path=':asset' element={<PerpsOverviewPage />} />

--- a/src/components/header/navigation/Routes.tsx
+++ b/src/components/header/navigation/Routes.tsx
@@ -18,9 +18,8 @@ export default function Routes() {
         }
       >
         <Route path='*' element={<Navigate to='/' />} />
-        <Route path='/' element={<MainPage />} />
+        <Route path='/' element={<Navigate to='/main' replace />} />
 
-        <Route path='/main' element={<MainPage />} />
         <Route path='/liquidations' element={<LiquidationsPage />} />
         <Route path='/perps' element={chainConfig.perps ? <PerpsOverviewPage /> : <MainPage />}>
           <Route path=':asset' element={<PerpsOverviewPage />} />

--- a/src/components/main/Liquidations/Table/LiquidationsTable.tsx
+++ b/src/components/main/Liquidations/Table/LiquidationsTable.tsx
@@ -16,7 +16,7 @@ export default function LiquidationsTable() {
   const [page, setPage] = useState<number>(1)
 
   const pageSize = 25
-  const maxEntries = 200
+  const maxEntries = 100
 
   const { data: liquidityData, isLoading: isLiquidityDataLoading } = useLiquidations(page, pageSize)
   const { data: assetsData } = useAssets()


### PR DESCRIPTION
Fixed: 
- having /main as the main url with `Home` tab as active

Hotfix:
- capped liquidations at 100 to avoid extra displayed pages
- this will be updated once `total` is added to the API sometimes this week