### PR TITLE
Include api key in API calls

### DIFF
--- a/src/api/assets/getDexAssets.ts
+++ b/src/api/assets/getDexAssets.ts
@@ -1,7 +1,8 @@
 import { convertAstroportAssetsResponse } from 'utils/assets'
+import { getUrl } from 'utils/url'
 
 export default async function getDexAssets(chainConfig: ChainConfig) {
-  const uri = new URL(chainConfig.endpoints.dexAssets)
+  const uri = getUrl(chainConfig.endpoints.dexAssets, '')
   try {
     const assets = await fetch(uri.toString()).then(async (res) => {
       const data = (await res.json()) as AstroportAssetsCached

--- a/src/api/assets/getDexPools.ts
+++ b/src/api/assets/getDexPools.ts
@@ -1,6 +1,9 @@
+import { getUrl } from 'utils/url'
+
 export default async function getDexPools(chainConfig: ChainConfig) {
   if (!chainConfig.endpoints.dexPools) return []
-  const uri = new URL(chainConfig.endpoints.dexPools)
+  const uri = getUrl(chainConfig.endpoints.dexPools, '')
+
   try {
     const pools = await fetch(uri.toString()).then(async (res) => {
       const data = (await res.json()) as AstroportPoolsCached

--- a/src/api/liquidations/getLiquidations.ts
+++ b/src/api/liquidations/getLiquidations.ts
@@ -1,16 +1,17 @@
 import { getApiBaseUrl } from 'utils/api'
 import { getChainName } from 'utils/getChainName'
 import { ChainInfoID } from 'types/enums'
+import { getUrl } from 'utils/url'
 
 export default async function getLiquidations(chainId: ChainInfoID, page = 1, pageSize = 25) {
   try {
     const baseUrl = getApiBaseUrl()
     const chain = getChainName(chainId)
-
-    const url = new URL(
-      `${baseUrl}/v2/liquidations?chain=${chain}&product=creditmanager&page=${page}&limit=${pageSize}&orders={"block_height":"desc"}`,
+    const url = getUrl(
+      baseUrl,
+      `/v2/liquidations?chain=${chain}&product=creditmanager&page=${page}&limit=${pageSize}&orders={"block_height":"desc"}`,
     )
-    const response = await fetch(url.toString())
+    const response = await fetch(url)
     const data = await response.json()
 
     return { data: data.data, total: data.total } as LiquidationsResponse

--- a/src/api/perps/getPerpsGlobalStats.ts
+++ b/src/api/perps/getPerpsGlobalStats.ts
@@ -3,6 +3,7 @@ import { DEFAULT_PERPS_GLOBAL_DATA } from 'constants/chartData'
 import { TIMEFRAME } from 'constants/timeframe'
 import { getApiBaseUrl } from 'utils/api'
 import { getCurrentChainId } from 'utils/getCurrentChainId'
+import { getUrl } from 'utils/url'
 
 export default async function getPerpsGlobalStats(timeframe: string = '30') {
   const chainId = getCurrentChainId()
@@ -15,10 +16,11 @@ export default async function getPerpsGlobalStats(timeframe: string = '30') {
       value: Number(timeframe),
     }
 
-    const url = new URL(
-      `${baseUrl}/v2/perps_overview?chain=neutron&granularity=${timeframeConfig.granularity}&unit=${timeframeConfig.value}&response_type=global`,
+    const url = getUrl(
+      baseUrl,
+      `/v2/perps_overview?chain=neutron&granularity=${timeframeConfig.granularity}&unit=${timeframeConfig.value}&response_type=global`,
     )
-    const response = await fetch(url.toString())
+    const response = await fetch(url)
     const data = (await response.json()) as PerpsGlobalOverview
 
     return data.global_overview

--- a/src/api/perps/getPerpsMarketStats.ts
+++ b/src/api/perps/getPerpsMarketStats.ts
@@ -1,6 +1,6 @@
 import { TIMEFRAME } from 'constants/timeframe'
 import { getApiBaseUrl } from 'utils/api'
-
+import { getUrl } from 'utils/url'
 export default async function getPerpsMarketStats(
   market: string = 'untrn',
   timeframe: string = '30',
@@ -11,10 +11,11 @@ export default async function getPerpsMarketStats(
       granularity: 'day',
       value: Number(timeframe),
     }
-    const url = new URL(
-      `${baseUrl}/v2/perps_overview?chain=neutron&granularity=${timeframeConfig.granularity}&unit=${timeframeConfig.value}&market=${market}&response_type=market`,
+    const url = getUrl(
+      baseUrl,
+      `/v2/perps_overview?chain=neutron&granularity=${timeframeConfig.granularity}&unit=${timeframeConfig.value}&market=${market}&response_type=market`,
     )
-    const response = await fetch(url.toString())
+    const response = await fetch(url)
     const data = (await response.json()) as PerpsMarketOverview
 
     return data.market_overview.data[0]

--- a/src/api/tokenomics/getMarsTokenPrice.ts
+++ b/src/api/tokenomics/getMarsTokenPrice.ts
@@ -2,9 +2,11 @@ import Neutron1 from 'chains/neutron/neutron-1'
 import { MARS_DENOM } from 'constants/mars'
 import { BN_ZERO } from 'constants/math'
 import { BN } from 'utils/helpers'
+import { getUrl } from 'utils/url'
 
 export default async function getMarsTokenPrice() {
-  const url = Neutron1.endpoints.dexAssets
+  const url = getUrl(Neutron1.endpoints.dexAssets, '')
+
   try {
     const response = await fetch(url)
     if (!response.ok) {

--- a/src/api/tokenomics/getOverviewData.ts
+++ b/src/api/tokenomics/getOverviewData.ts
@@ -1,17 +1,20 @@
 import { ChainInfoID } from 'types/enums'
 import { getApiBaseUrl } from 'utils/api'
 import { getChainName } from 'utils/getChainName'
+import { getUrl } from 'utils/url'
 
 export default async function getOverviewData(chainId: ChainInfoID, timeframe: string = '30') {
   try {
     const baseUrl = getApiBaseUrl()
     const chain = getChainName(chainId)
 
-    const url = new URL(
-      `${baseUrl}/v2/overview?chain=${chain}&days=${timeframe}&product=creditmanager`,
+    const url = getUrl(
+      baseUrl,
+      `/v2/overview?chain=${chain}&days=${timeframe}&product=creditmanager`,
     )
-    const response = await fetch(url.toString())
+    const response = await fetch(url)
     const data = (await response.json()) as Overview
+
     return data.data[0] as OverviewData
   } catch (error) {
     console.error('Could not fetch overview data.', error)

--- a/src/constants/query.ts
+++ b/src/constants/query.ts
@@ -1,4 +1,4 @@
-export const ITEM_LIMIT_PER_QUERY = 5
+export const ITEM_LIMIT_PER_QUERY = 4
 export const PRICE_ORACLE_DECIMALS = 6
 export const PRICE_STALE_TIME = 30_000
 export const FETCH_TIMEOUT = 6_000

--- a/src/hooks/liquidations/useLiquidations.ts
+++ b/src/hooks/liquidations/useLiquidations.ts
@@ -12,7 +12,6 @@ export default function useLiquidations(page = 1, pageSize = 25) {
     },
     {
       refreshInterval: 120_000,
-      suspense: true,
     },
   )
 }

--- a/src/hooks/perps/usePerpsVault.ts
+++ b/src/hooks/perps/usePerpsVault.ts
@@ -5,8 +5,9 @@ import { PERPS_DEFAULT_ACTION } from 'constants/perps'
 import { FETCH_TIMEOUT } from 'constants/query'
 import useChainConfig from 'hooks/chain/useChainConfig'
 import useClients from 'hooks/chain/useClients'
-import { BN } from 'utils/helpers'
 import { fetchWithTimeout } from 'utils/fetch'
+import { BN } from 'utils/helpers'
+import { getUrl } from 'utils/url'
 
 export default function usePerpsVault() {
   const chainConfig = useChainConfig()
@@ -21,7 +22,7 @@ export default function usePerpsVault() {
       try {
         if (chainConfig.endpoints.aprs.perpsVault) {
           const response = await fetchWithTimeout(
-            chainConfig.endpoints.aprs.perpsVault,
+            getUrl(chainConfig.endpoints.aprs.perpsVault, ''),
             FETCH_TIMEOUT,
           )
           if (response.ok) {

--- a/src/hooks/vaults/useVaultAprs.ts
+++ b/src/hooks/vaults/useVaultAprs.ts
@@ -1,7 +1,10 @@
 import useSWR from 'swr'
 
+import { FETCH_TIMEOUT } from 'constants/query'
 import useChainConfig from 'hooks/chain/useChainConfig'
+import { fetchWithTimeout } from 'utils/fetch'
 import { convertAprToApy } from 'utils/parsers'
+import { getUrl } from 'utils/url'
 
 export default function useVaultAprs() {
   const chainConfig = useChainConfig()
@@ -14,7 +17,10 @@ export default function useVaultAprs() {
 async function getAprs(chainConfig: ChainConfig) {
   if (!chainConfig.farm) return []
   try {
-    const response = await fetch(chainConfig.endpoints.aprs.vaults)
+    const response = await fetchWithTimeout(
+      getUrl(chainConfig.endpoints.aprs.vaults, ''),
+      FETCH_TIMEOUT,
+    )
 
     if (response.ok) {
       const data: AprResponse = await response.json()

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -3,10 +3,11 @@ export const getUrl = (baseUrl: string, path: string = ''): string => {
 
   if (isPlaceholder) return baseUrl + '/' + path
 
-  const url = new URL(baseUrl.split('?')[0])
+  let url = new URL(baseUrl)
+  if (path !== '') url = new URL(path, url)
 
   if (process.env.NEXT_PUBLIC_API_KEY)
-    return `${url.href}${path}?x-apikey=${process.env.NEXT_PUBLIC_API_KEY}`
+    url.searchParams.append('x-apikey', process.env.NEXT_PUBLIC_API_KEY)
 
-  return url.href + path
+  return url.toString()
 }


### PR DESCRIPTION
- lowered the limit for requests
- refactored API calls to include `getUrl()`